### PR TITLE
added controller response exception handling

### DIFF
--- a/Factory/ClientFactory.php
+++ b/Factory/ClientFactory.php
@@ -48,7 +48,8 @@ class ClientFactory
     public function create(): Client
     {
         if (empty($this->config['apiKey'])) {
-            $client = Client::make();
+            // provide any string as argument so no exception will be thrown
+            $client = Client::make('empty');
         } else {
             $client = Client::make($this->config['apiKey']);
         }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,8 +13,8 @@
         </testsuite>
     </testsuites>
 
-    <filter processUncoveredFilesFromWhitelist="true">
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <filter>
+        <whitelist>
             <directory suffix=".php">./Factory</directory>
             <directory suffix=".php">./Subscriber</directory>
             <file>BestItBugsnag.php</file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,10 +4,15 @@
     <label lang="de">best it - Shopware Bugsnag</label>
     <label lang="en">best it - Shopware Bugsnag</label>
 
-    <version>1.1.1</version>
-    <link>https://www.bestit-online.de</link>
-    <author>best it GmbH &amp; Co. KG</author>
+    <version>1.2.0</version>
+    <link>https://www.bestit.de</link>
+    <author>best it AG</author>
     <compatibility minVersion="5.4.0" />
+
+    <changelog version="1.2.0">
+        <changes lang="de">Controller-Response-Exceptions hinzugefügt</changes>
+        <changes lang="en">Controller-Response-Exceptions added</changes>
+    </changelog>
 
     <changelog version="1.1.1">
         <changes lang="de">Pluginversion mit tag version angeglichen</changes>


### PR DESCRIPTION
Because SW in prod env is catching everything, i added this handler to read the exceptions from controller response and push them to bugsnag.
I also optimized the behavior when the api key is missing - an exception will not be thrown any more.